### PR TITLE
scrape : Add support for bmp files

### DIFF
--- a/uiplib/scrape.py
+++ b/uiplib/scrape.py
@@ -49,7 +49,7 @@ def get_images(url):
         return
 
     for link in thumbnails:
-        if link['href'].endswith(('jpg', 'png', 'jpeg')):
+        if link['href'].endswith(('jpg', 'png', 'jpeg','bmp')):
             image_links.append(link['href'])
         if(len(image_links) == NUMBER_OF_IMAGES_TO_PARSE):
             break


### PR DESCRIPTION
The scrape.py file now supports bmp image file
Fixes #32 