### PR TITLE
UIP now runs as a service on linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from uiplib.settings import (HOME_DIR,
 import sys
 import os
 import json
+import shutil
 
 def get_contents(filename):
     file = open(filename, 'r').readlines()
@@ -15,8 +16,10 @@ def get_contents(filename):
     return out
 
 #Make Home Directory
-if not os.path.exists(HOME_DIR):
-    os.makedirs(HOME_DIR)
+if os.path.exists(HOME_DIR):
+    shutil.rmtree(HOME_DIR)
+
+os.makedirs(HOME_DIR)
 
 if not os.path.isfile(settings_file_path):
     file_data = {'timeout' : 30*60,

--- a/uiplib/UIP.py
+++ b/uiplib/UIP.py
@@ -1,36 +1,66 @@
 import sys, os, shutil
 from uiplib.settings import ParseSettings
 from uiplib.scheduler import scheduler
+if sys.platform.startswith('linux'):
+    from uiplib.daemon import daemon
+
+settings = None
+
+class UIP:
+    def run(self):
+        global settings
+        print("Hey this is UIP! you can use it to download"
+              " images from reddit and also to schedule the setting of these"
+              " images as your desktop wallpaper.")
+        try:
+            if settings['offline']:
+                print("You have choosen to run UIP in offline mode.")
+            if settings['flush']:
+                print("Deleting all downloaded wallpapers...")
+                try:
+                    shutil.rmtree(settings['pics-folder'])
+                    os.mkdir(settings['pics-folder'])
+                except FileNotFoundError:
+                    pass
+            if not settings['offline']:
+                print("UIP will now connect to internet and download images"
+                      " from reddit.")
+            scheduler(settings['offline'],
+                      settings['pics-folder'],
+                      settings['timeout'],
+                      settings['website'][0],
+                      settings['no-of-images'])
+        except KeyboardInterrupt:
+            print("\nExiting UIP hope you had a nice time :)")
+            sys.exit(0)
+
+class UIPDaemon(daemon):
+    def run(self):
+        uip = UIP()
+        uip.run()
 
 def main():
-    print("Hey this is UIP! you can use it to download"
-          " images from reddit and also to schedule the setting of these"
-          " images as your desktop wallpaper.")
-
+    global settings
     settingsParser = ParseSettings()
     settings = settingsParser.settings
-    try:
-        if settings['error']:
-            print("\nWRONG USAGE OF FLAGS --no-of-images AND --offline")
-            settingsParser.show_help()
-            sys.exit(0)
-        if settings['offline']:
-            print("You have choosen to run UIP in offline mode.")
-        if settings['flush']:
-            print("Deleting all downloaded wallpapers...")
-            try:
-                shutil.rmtree(settings['pics-folder'])
-                os.mkdir(settings['pics-folder'])
-            except FileNotFoundError:
-                pass
-        if not settings['offline']:
-            print("UIP will now connect to internet and download images"
-                  " from reddit.")
-        scheduler(settings['offline'],
-                  settings['pics-folder'],
-                  settings['timeout'],
-                  settings['website'][0],
-                  settings['no-of-images'])
-    except KeyboardInterrupt:
-        print("Exiting UIP hope you had a nice time :)")
+    if settings['error']:
+        print("\nWRONG USAGE OF FLAGS --no-of-images AND --offline")
+        settingsParser.show_help()
         sys.exit(0)
+    if settings['service'] and not sys.platform.startswith('win32'):
+        daemon = UIPDaemon('/tmp/daemon-uip.pid')
+        if 'start' == str(settings['service']):
+            daemon.start()
+        elif 'stop' == str(settings['service']):
+            daemon.stop()
+        elif 'restart' == str(settings['service']):
+            daemon.restart()
+        else:
+            print("Unknown command")
+            sys.exit(2)
+    elif settings['service'] and sys.platform.startswith('win32'):
+        print("Sorry, UIP as a service is not yet developed for your OS!")
+        sys.exit(1)
+    else:
+        uip = UIP()
+        uip.run()

--- a/uiplib/daemon.py
+++ b/uiplib/daemon.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env
+# -*- coding: utf-8 -*-
+
+"""Generic linux daemon base class for python 3.x."""
+
+import sys
+import os
+import time
+import atexit
+import signal
+
+
+class daemon:
+
+    """A generic daemon class.
+
+....Usage: subclass the daemon class and override the run() method."""
+
+    def __init__(self, pidfile):
+        self.pidfile = pidfile
+
+    def daemonize(self):
+        """Deamonize class. UNIX double fork mechanism."""
+
+        try:
+            pid = os.fork()
+            if pid > 0:
+                # exit first parent
+                sys.exit(0)
+        except OSError as err:
+            sys.stderr.write('fork #1 failed: {0}\n'.format(err))
+            sys.exit(1)
+        # decouple from parent environment
+
+        os.chdir('/')
+        os.setsid()
+        os.umask(0)
+
+        # do second fork
+
+        try:
+            pid = os.fork()
+            if pid > 0:
+                # exit from second parent
+                sys.exit(0)
+        except OSError as err:
+            sys.stderr.write('fork #2 failed: {0}\n'.format(err))
+            sys.exit(1)
+
+        # redirect standard file descriptors
+
+        sys.stdout.flush()
+        sys.stderr.flush()
+        si = open(os.devnull, 'r')
+        so = open(os.devnull, 'a+')
+        se = open(os.devnull, 'a+')
+
+        os.dup2(si.fileno(), sys.stdin.fileno())
+        os.dup2(so.fileno(), sys.stdout.fileno())
+        os.dup2(se.fileno(), sys.stderr.fileno())
+
+        # write pidfile
+
+        atexit.register(self.delpid)
+
+        pid = str(os.getpid())
+        with open(self.pidfile, 'w+') as f:
+            f.write(pid + '\n')
+
+    def delpid(self):
+        os.remove(self.pidfile)
+
+    def start(self):
+        """Start the daemon."""
+
+        # Check for a pidfile to see if the daemon already runs
+
+        try:
+            with open(self.pidfile, 'r') as pf:
+
+                pid = int(pf.read().strip())
+        except IOError:
+            pid = None
+
+        if pid:
+            message = 'pidfile {0} already exist. ' \
+                + 'Daemon already running?\n'
+            sys.stderr.write(message.format(self.pidfile))
+            sys.exit(1)
+
+        # Start the daemon
+
+        self.daemonize()
+        self.run()
+
+    def stop(self):
+        """Stop the daemon."""
+
+        # Get the pid from the pidfile
+
+        try:
+            with open(self.pidfile, 'r') as pf:
+                pid = int(pf.read().strip())
+        except IOError:
+            pid = None
+
+        if not pid:
+            message = 'pidfile {0} does not exist. ' \
+                + 'Daemon not running?\n'
+            sys.stderr.write(message.format(self.pidfile))
+            return   # not an error in a restart
+
+        # Try killing the daemon process....
+
+        try:
+            while 1:
+                os.kill(pid, signal.SIGTERM)
+                time.sleep(0.1)
+        except OSError as err:
+            e = str(err.args)
+            if e.find('No such process') > 0:
+                if os.path.exists(self.pidfile):
+                    os.remove(self.pidfile)
+            else:
+                print(str(err.args))
+                sys.exit(1)
+
+    def restart(self):
+        """Restart the daemon."""
+
+        self.stop()
+        self.start()
+
+    def run(self):
+        """You should override this method when you subclass Daemon.
+........
+........It will be called after the process has been daemonized by
+........start() or restart()."""

--- a/uiplib/scheduler.py
+++ b/uiplib/scheduler.py
@@ -9,7 +9,7 @@ from select import select
 try:
     import msvcrt
 except ImportError:
-    #not on windows
+    #msvcrt module is only available on windows
     pass
 
 class scheduler():
@@ -73,16 +73,15 @@ class scheduler():
 
     def changeCycle(self):
         while True:
-            if not self.kbhit():
+            if self.kbhit() and self.getch() == 's':
+                print("Skipping this wallpaper")
+                self.change_random()
+                self.time = time.time()
+            else:
                 delta = self.deltaTime()
                 if delta >= self.timeout:
                     self.change_random()
                     self.time = time.time()
-            else:
-                self.getch()
-                print("Skipping this wallpaper")
-                self.change_random()
-                self.time = time.time()
 
     def setStartTime(self, time):
         self.time = time

--- a/uiplib/settings.py
+++ b/uiplib/settings.py
@@ -20,6 +20,11 @@ class ParseSettings:
 
     def get_settings_from_cli(self):
         self.parser = argparse.ArgumentParser()
+        self.parser.add_argument("--service",
+                            help="Run UIP as a service, "
+                            "--service start: to start UIP, "
+                            "--service stop: to stop UIP, "
+                            "--service restart: to restart UIP\n")
         self.parser.add_argument("--offline", action="store_true",
                         help="Runs UIP in offline mode.")
         self.parser.add_argument("--flush", action="store_true",
@@ -34,6 +39,7 @@ class ParseSettings:
         args = self.parser.parse_args()
 
         settings = {
+            'service' : args.service,
             'offline': args.offline,
             'flush': args.flush,
             'error': args.no_of_images and args.offline,
@@ -45,4 +51,3 @@ class ParseSettings:
 
     def show_help(self):
         self.parser.print_help()
-


### PR DESCRIPTION
To run UIP as a service: UIP --service [option]
option = start, to start
           = stop, to stop
           = restart, to restart
Can also be combined with other available flags.
Also a change to be noted is, now press 's' + enter when running as a script to skip current wallpaper
Partially fixes issue 97along with a few minor fixes.

Fixes #97