### PR TITLE
Fix --service on Linux

### DIFF
--- a/uiplib/UIP.py
+++ b/uiplib/UIP.py
@@ -58,7 +58,8 @@ def main():
                   settings['pics-folder'],
                   settings['timeout'],
                   settings['website'],
-                  settings['no-of-images'])
+                  settings['no-of-images'],
+                  settings['service'])
     except KeyboardInterrupt:
         exit_UIP()
 

--- a/uiplib/scheduler.py
+++ b/uiplib/scheduler.py
@@ -19,11 +19,12 @@ except ImportError:
 
 class scheduler():
 
-    def __init__(self, offline, pics_folder, timout, website, count):
+    def __init__(self, offline, pics_folder, timeout, website, count, service):
         self.website = website
-        self.timeout = timout
+        self.timeout = timeout
         self.directory = pics_folder
         self.count = count
+        self.service = service
 
         if not offline:
             try:
@@ -66,6 +67,8 @@ class scheduler():
     def kbhit(self):
         ''' Returns True if keyboard character was hit, False otherwise.
         '''
+        if self.service:
+            return False
         if os.name == 'nt':
             return msvcrt.kbhit()
         else:


### PR DESCRIPTION
UIP service was getting kbhit() continously,
causing it to change wallpapers.
Makes sure kbhit() is never true when UIP is
running as service.

Fixes #217