### PR TITLE
Truncated Error, caused due to large images

### DIFF
--- a/uiplib/uipImage.py
+++ b/uiplib/uipImage.py
@@ -2,8 +2,9 @@
 
 import os
 
-from PIL import Image, ImageFilter
+from PIL import Image, ImageFilter, ImageFile
 
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 class UipImage:  # pragma: no cover
     """Class that holds the image as well as the functions used to edit it."""


### PR DESCRIPTION
![error_final](https://cloud.githubusercontent.com/assets/6323849/23957812/4ae41dd2-09c6-11e7-97ee-1ab68669afea.jpg)

Allowing truncated images has two advantages, for the time being, it won't be spitting out errors that is caused to sudden termination of connection, also large images that might have being causing this issue will be resolved. Whatever the cause of that error might be, it prevented UIP to further launch, so thought this would be a useful addition. Though opinions are welcome :)